### PR TITLE
Make copyright holder more explicit to ease software redistribution

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,3 +1,9 @@
+/*
+  * Copyright (C) 2019-2020 Simon Ser <contact@emersion.fr>
+  * SPDX-License-Identifier: MIT
+  * Author: Simon Ser <contact@emersion.fr>
+  */
+
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <errno.h>

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,10 @@ project(
 	],
 )
 
+author = 'emersion'
+authorfullname = 'Simon Ser'
+authoremail = 'contact@emersion.fr'
+
 cc = meson.get_compiler('c')
 
 add_project_arguments(cc.get_supported_arguments([


### PR DESCRIPTION
Hello Simon,

This PR adds some details regarding copyright holder, yourself, which willl ease packaging the application into linux distributions.
I will be working on getting wlr-randr into debian and this will come as a requirement so that the package is allowed in the distribution.

Thanks in advance and best regards,