### PR TITLE
Fix mode not being found when setting mode, even when copied and past…

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -429,7 +430,7 @@ static bool parse_mode(const char *value, int *width, int *height,
 				return false;
 			}
 
-			*refresh = refresh_hz * 1000; // Hz → mHz
+			*refresh = (round(refresh_hz * 1000)); // Hz → mHz
 		}
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -36,11 +36,13 @@ add_project_arguments(cc.get_supported_arguments([
 
 wayland_client = dependency('wayland-client')
 
+m_dep = cc.find_library('m', required : false)
+
 subdir('protocol')
 
 wlr_randr_exe = executable(
 	meson.project_name(),
 	files(['main.c']),
-	dependencies: [wayland_client, client_protos],
+	dependencies: [wayland_client, client_protos, m_dep],
 	install: true,
 )


### PR DESCRIPTION
…ed from mode list

The issue is that all available mode refresh rates are stored in wlr-randr as an integer number of mHz, while when listing available modes, modes are listed in Hz to six decimal places. When converting a `--mode` option given to mHz, it is rounded down, while the list of modes internally is rounded to the nearest mHz.

As an example, wlr-randr might list an available mode as "2560x1440 px, 169.830994 Hz". The user tries switching to it with "--mode 2560x1440@169.830994Hz", and the mode option is truncated to 169830, which is different to the 169831 in the list of available modes.